### PR TITLE
Debug extended euclid null pointer crash

### DIFF
--- a/BigInteger.cpp
+++ b/BigInteger.cpp
@@ -173,6 +173,9 @@ namespace TwilightDream::BigInteger
 		const size_t this_size = values.size();
 		const size_t other_size = other.values.size();
 
+		// Ensure destination has enough capacity for in-place subtraction
+		values.resize( std::max( this_size, other_size ) );
+
 		// Perform subtraction for each digit
 		HyperInt::Arithmetic::abs_sub_binary( values.data(), this_size, other.values.data(), other_size, values.data() );
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resize `BigInteger::values` before in-place subtraction to prevent crashes when the left operand is zero.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `BigInteger::Subtract` method performed an in-place write to `values.data()`. When the `BigInteger` object was zero (meaning its `values` vector was empty), `values.data()` returned a pointer that was not safe for writing, leading to a null pointer dereference and crash. This fix ensures the buffer is properly sized before the subtraction.

---
<a href="https://cursor.com/background-agent?bcId=bc-81045ab7-3546-45de-a50e-56062e641e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81045ab7-3546-45de-a50e-56062e641e59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

